### PR TITLE
Fix ChromaDB API error: replace query_collection with query_documents

### DIFF
--- a/docs/tutorials/WORKFLOW_TUTORIALS.md
+++ b/docs/tutorials/WORKFLOW_TUTORIALS.md
@@ -349,14 +349,14 @@ class DailyReviewPlugin(PluginBase):
                 chroma = ChromaManager()
                 
                 # Get recent context
-                recent_context = chroma.query_collection(
+                recent_context = chroma.query_documents(
                     "active_context_stream",
                     query_texts=["daily work context"],
                     n_results=5
                 )
                 
                 # Get highlights
-                highlights = chroma.query_collection(
+                highlights = chroma.query_documents(
                     "float_highlights",
                     query_texts=["important insights"],
                     n_results=3
@@ -559,7 +559,7 @@ class PatternAnalyzerPlugin(PluginBase):
                 chroma = ChromaManager()
                 
                 # Get documents from collection
-                results = chroma.query_collection(
+                results = chroma.query_documents(
                     collection,
                     query_texts=["patterns analysis"],
                     n_results=limit
@@ -599,7 +599,7 @@ class PatternAnalyzerPlugin(PluginBase):
                 
                 for collection in collections:
                     try:
-                        results = chroma.query_collection(
+                        results = chroma.query_documents(
                             collection,
                             query_texts=[pattern],
                             n_results=20
@@ -678,7 +678,7 @@ class PatternAnalyzerPlugin(PluginBase):
                     total_count = 0
                     for collection in ["active_context_stream", "float_highlights", "conversation_highlights"]:
                         try:
-                            results = chroma.query_collection(
+                            results = chroma.query_documents(
                                 collection,
                                 query_texts=[pattern],
                                 n_results=50
@@ -827,7 +827,7 @@ def similar_patterns(ctx: click.Context, threshold: float) -> None:
         chroma = ChromaManager()
         
         # Get all context markers
-        ctx_results = chroma.query_collection(
+        ctx_results = chroma.query_documents(
             "active_context_stream",
             query_texts=["ctx::"],
             n_results=50

--- a/src/floatctl/mcp_server.py
+++ b/src/floatctl/mcp_server.py
@@ -1806,7 +1806,7 @@ async def smart_chroma_query(
             )
         else:
             # Use generic query for other collections
-            results = chroma.query_collection(
+            results = chroma.query_documents(
                 collection_name=collection,
                 query_texts=[query],
                 n_results=limit,
@@ -1824,7 +1824,7 @@ async def smart_chroma_query(
                 formatted_results.append(item)
                 total_content += content + "\n"
         else:
-            # From query_collection
+            # From query_documents
             docs = results.get("documents", [[]])[0]
             metas = results.get("metadatas", [[]])[0]
             distances = results.get("distances", [[]])[0]


### PR DESCRIPTION
## Summary
Fixes the ChromaDB API error where query_collection method does not exist by replacing it with the correct query_documents method.

## Changes Made
- **MCP Server Fix**: Updated smart_chroma_query function to use query_documents instead of query_collection
- **Documentation Update**: Fixed all examples in WORKFLOW_TUTORIALS.md to use correct method name
- **Comment Update**: Updated code comment to reflect the correct method name

## Root Cause
ChromaDB 1.0.10 API changed - the ChromaClient class has query_documents method, not query_collection.

## Testing
- Verified ChromaClient has query_documents method
- Confirmed query_collection method does not exist  
- Successfully imported MCP server after changes
- No syntax or import errors

## Impact
- Fixes evna-context-concierge smart_chroma_query tool failure
- Restores MCP server ChromaDB functionality
- Updates documentation to prevent future confusion

## Related
Fixes #29

ctx::2025-08-14 [mode:: debugging] [project:: floatctl/mcp]