### PR TITLE
Add Chrome extension skeleton for Claude conversation archaeologist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ test-scratch/
 *.html
 !docs/**/*.html
 !examples/**/*.html
+!chrome_extension/*.html
 
 # Analysis output files
 *conversation_analysis*

--- a/chrome_extension/artifact-detector.js
+++ b/chrome_extension/artifact-detector.js
@@ -1,0 +1,4 @@
+export function artifactDetector(message) {
+  // TODO: Detect code, documents, or charts within message content
+  return { code: [], documents: [], charts: [] };
+}

--- a/chrome_extension/cache-daemon.js
+++ b/chrome_extension/cache-daemon.js
@@ -1,0 +1,11 @@
+self.addEventListener('install', () => {
+  console.log('Cache daemon installed');
+});
+
+self.addEventListener('activate', () => {
+  console.log('Cache daemon activated');
+});
+
+self.addEventListener('message', event => {
+  console.log('Cache daemon received message', event.data);
+});

--- a/chrome_extension/control-interface.html
+++ b/chrome_extension/control-interface.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Conversation Consciousness</title>
+</head>
+<body>
+  <button id="export-markdown">Export Markdown</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome_extension/conversation-archaeologist.js
+++ b/chrome_extension/conversation-archaeologist.js
@@ -1,0 +1,9 @@
+import { conversationParser } from './conversation-parser.js';
+import { storageManager } from './storage-manager.js';
+
+(function () {
+  console.log('Conversation Archaeologist content script loaded');
+
+  const conversation = conversationParser();
+  storageManager.save(conversation);
+})();

--- a/chrome_extension/conversation-parser.js
+++ b/chrome_extension/conversation-parser.js
@@ -1,0 +1,10 @@
+export function conversationParser() {
+  // TODO: Extract metadata and messages from the current page
+  return {
+    metadata: {},
+    messages: [],
+    artifacts: { code: [], documents: [], charts: [] },
+    tags: [],
+    folder: null
+  };
+}

--- a/chrome_extension/export-engine.js
+++ b/chrome_extension/export-engine.js
@@ -1,0 +1,12 @@
+export const exportEngine = {
+  toMarkdown(conversation) {
+    // TODO: Build markdown representation
+    return `# Conversation Export\n`;
+  },
+  toJSON(conversation) {
+    return JSON.stringify(conversation, null, 2);
+  },
+  toPDF(conversation) {
+    // TODO: Generate PDF file
+  }
+};

--- a/chrome_extension/folder-hierarchy.js
+++ b/chrome_extension/folder-hierarchy.js
@@ -1,0 +1,7 @@
+export const folderHierarchy = {
+  tree: {},
+  add(path) {
+    // TODO: Add folder path to hierarchy
+    this.tree[path] = this.tree[path] || {};
+  }
+};

--- a/chrome_extension/interface-overlay.css
+++ b/chrome_extension/interface-overlay.css
@@ -1,0 +1,10 @@
+#conversation-archaeologist-overlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 100%;
+  background: #fff;
+  border-left: 1px solid #ccc;
+  z-index: 9999;
+}

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Claude Conversation Archaeologist",
+  "version": "1.0.0",
+  "description": "Archive, organize, and transcend your Claude.ai conversations",
+  "permissions": ["storage", "activeTab", "tabs", "background", "contextMenus"],
+  "host_permissions": ["*://claude.ai/*"],
+  "content_scripts": [{
+    "matches": ["*://claude.ai/chat/*"],
+    "js": ["conversation-archaeologist.js"],
+    "css": ["interface-overlay.css"]
+  }],
+  "background": {
+    "service_worker": "cache-daemon.js"
+  },
+  "action": {
+    "default_popup": "control-interface.html",
+    "default_title": "Conversation Consciousness"
+  }
+}

--- a/chrome_extension/popup.js
+++ b/chrome_extension/popup.js
@@ -1,0 +1,3 @@
+document.getElementById('export-markdown').addEventListener('click', () => {
+  console.log('Export as Markdown clicked');
+});

--- a/chrome_extension/search-engine.js
+++ b/chrome_extension/search-engine.js
@@ -1,0 +1,4 @@
+export function searchEngine(query, conversations) {
+  // TODO: Implement fuzzy search across stored conversations
+  return conversations.filter(() => false);
+}

--- a/chrome_extension/storage-manager.js
+++ b/chrome_extension/storage-manager.js
@@ -1,0 +1,8 @@
+export const storageManager = {
+  async save(conversation) {
+    // TODO: Persist conversation to local storage
+    return new Promise(resolve => {
+      chrome.storage.local.set({ [conversation.metadata.url || Date.now()]: conversation }, resolve);
+    });
+  }
+};

--- a/chrome_extension/sync-daemon.js
+++ b/chrome_extension/sync-daemon.js
@@ -1,0 +1,4 @@
+export function syncDaemon() {
+  // TODO: Sync local cache with remote storage
+  console.log('Sync daemon initialized');
+}

--- a/chrome_extension/tag-system.js
+++ b/chrome_extension/tag-system.js
@@ -1,0 +1,9 @@
+export const tagSystem = {
+  tags: new Set(),
+  add(tag) {
+    this.tags.add(tag);
+  },
+  list() {
+    return Array.from(this.tags);
+  }
+};


### PR DESCRIPTION
## Summary
- scaffold Chrome extension for archiving Claude.ai conversations
- include manifest, content script, background service worker, popup UI, and placeholder modules
- add control interface HTML and allow extension HTML files in version control

## Testing
- `uv sync`
- `uv run ruff check src/` *(fails: 286 errors)*
- `uv run ruff format src/ --check` *(fails: parse error in chroma_tools_backup.py)*
- `uv run mypy src/` *(fails: `{` was never closed)*
- `uv run pytest` *(fails: NameError and FileNotFoundError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c602b29e708330b4e1c0b5694e5cc1